### PR TITLE
SocketSelector::wait returns number of ready sockets

### DIFF
--- a/include/SFML/Network/SocketSelector.hpp
+++ b/include/SFML/Network/SocketSelector.hpp
@@ -111,16 +111,17 @@ public:
     /// some data available to be received. To know which sockets are
     /// ready, use the isReady function.
     /// If you use a timeout and no socket is ready before the timeout
-    /// is over, the function returns false.
+    /// is over, the function returns zero.
+    /// If an error occured, the function returns -1 (see POSIX select(2)).
     ///
     /// \param timeout Maximum time to wait, (use Time::Zero for infinity)
     ///
-    /// \return True if there are sockets ready, false otherwise
+    /// \return Number of ready sockets, or -1 if an error occured.
     ///
     /// \see isReady
     ///
     ////////////////////////////////////////////////////////////
-    bool wait(Time timeout = Time::Zero);
+    int wait(Time timeout = Time::Zero);
 
     ////////////////////////////////////////////////////////////
     /// \brief Test a socket to know if it is ready to receive data

--- a/src/SFML/Network/SocketSelector.cpp
+++ b/src/SFML/Network/SocketSelector.cpp
@@ -153,7 +153,7 @@ void SocketSelector::clear()
 
 
 ////////////////////////////////////////////////////////////
-bool SocketSelector::wait(Time timeout)
+int SocketSelector::wait(Time timeout)
 {
     // Setup the timeout
     timeval time;
@@ -167,7 +167,7 @@ bool SocketSelector::wait(Time timeout)
     // The first parameter is ignored on Windows
     int count = select(m_impl->maxSocket + 1, &m_impl->socketsReady, NULL, NULL, timeout != Time::Zero ? &time : NULL);
 
-    return count > 0;
+    return count;
 }
 
 


### PR DESCRIPTION
I changed SocketSelector::wait to return the number of ready sockets. After this function returned, you have to iterate over all registered sockets to know which ones are ready. If you know the number of ready sockets, the iteration can be stopped earlier. As the [man page of POSIX select(2)](http://man7.org/linux/man-pages/man2/select.2.html) describes, the returned value is -1 if an error occurred.